### PR TITLE
Fix 165 for 1.7.x (#179)

### DIFF
--- a/spring-cloud-zuul-ratelimit-core/pom.xml
+++ b/spring-cloud-zuul-ratelimit-core/pom.xml
@@ -165,6 +165,11 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>commons-net</groupId>
+            <artifactId>commons-net</artifactId>
+            <version>3.6</version>
+        </dependency>
 
     </dependencies>
 

--- a/spring-cloud-zuul-ratelimit-core/src/main/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/config/properties/RateLimitType.java
+++ b/spring-cloud-zuul-ratelimit-core/src/main/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/config/properties/RateLimitType.java
@@ -18,10 +18,12 @@ package com.marcosbarbero.cloud.autoconfigure.zuul.ratelimit.config.properties;
 
 import com.marcosbarbero.cloud.autoconfigure.zuul.ratelimit.config.RateLimitUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.net.util.SubnetUtils;
 import org.springframework.cloud.netflix.zuul.filters.Route;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.Optional;
+
 
 public enum RateLimitType {
     /**
@@ -30,6 +32,15 @@ public enum RateLimitType {
     ORIGIN {
         @Override
         public boolean apply(HttpServletRequest request, Route route, RateLimitUtils rateLimitUtils, String matcher) {
+            if(matcher.contains("/")) {
+                try {
+                    SubnetUtils cidr = new SubnetUtils(matcher);
+                    return cidr.getInfo().isInRange(rateLimitUtils.getRemoteAddress(request));
+                }
+                catch(Exception e) {
+                    return false;
+                }
+            }
             return matcher.equals(rateLimitUtils.getRemoteAddress(request));
         }
 

--- a/spring-cloud-zuul-ratelimit-core/src/main/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/filters/AbstractRateLimitFilter.java
+++ b/spring-cloud-zuul-ratelimit-core/src/main/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/filters/AbstractRateLimitFilter.java
@@ -62,8 +62,8 @@ public abstract class AbstractRateLimitFilter extends ZuulFilter {
         String routeId = Optional.ofNullable(route).map(Route::getId).orElse(null);
         alreadyLimited = false;
         return properties.getPolicies(routeId).stream()
-                .filter(policy -> applyPolicy(request, route, policy))
-                .collect(Collectors.toList());
+            .filter(policy -> applyPolicy(request, route, policy))
+            .collect(Collectors.toList());
     }
 
     private boolean applyPolicy(HttpServletRequest request, Route route, Policy policy) {

--- a/spring-cloud-zuul-ratelimit-tests/springdata/src/main/java/com/marcosbarbero/tests/SpringDataApplication.java
+++ b/spring-cloud-zuul-ratelimit-tests/springdata/src/main/java/com/marcosbarbero/tests/SpringDataApplication.java
@@ -61,5 +61,15 @@ public class SpringDataApplication {
         public ResponseEntity<String> serviceG() {
             return ResponseEntity.ok(RESPONSE_BODY);
         }
+
+        @GetMapping("/serviceH")
+        public ResponseEntity<String> serviceH() {
+            return ResponseEntity.ok(RESPONSE_BODY);
+        }
+
+        @GetMapping("/serviceI")
+        public ResponseEntity<String> serviceI() {
+            return ResponseEntity.ok(RESPONSE_BODY);
+        }
     }
 }

--- a/spring-cloud-zuul-ratelimit-tests/springdata/src/main/resources/application.yml
+++ b/spring-cloud-zuul-ratelimit-tests/springdata/src/main/resources/application.yml
@@ -46,6 +46,12 @@ zuul:
     serviceG:
       path: /serviceG
       url: forward:/
+    serviceH:
+      path: /serviceH
+      url: forward:/
+    serviceI:
+      path: /serviceI
+      url: forward:/
   ratelimit:
     enabled: true
     repository: JPA
@@ -80,6 +86,7 @@ zuul:
           refresh-interval: 60
           type:
             - origin
+          breakOnMatch: true
       serviceG:
         - limit: 2
           refresh-interval: 60
@@ -90,6 +97,29 @@ zuul:
           refresh-interval: 60
           type:
             - origin
+          breakOnMatch: true
+      serviceH:
+        - limit: 2
+          refresh-interval: 60
+          type:
+            - origin=127.0.0.0/22
+          breakOnMatch: true
+        - limit: 1
+          refresh-interval: 60
+          type:
+            - origin
+          breakOnMatch: true
+      serviceI:
+        - limit: 2
+          refresh-interval: 60
+          type:
+            - origin=126.0.0.0/22
+          breakOnMatch: true
+        - limit: 1
+          refresh-interval: 60
+          type:
+            - origin
+          breakOnMatch: true
   strip-prefix: true
 
 logging:

--- a/spring-cloud-zuul-ratelimit-tests/springdata/src/test/java/com/marcosbarbero/tests/it/SpringDataApplicationTestIT.java
+++ b/spring-cloud-zuul-ratelimit-tests/springdata/src/test/java/com/marcosbarbero/tests/it/SpringDataApplicationTestIT.java
@@ -129,13 +129,27 @@ public class SpringDataApplicationTestIT {
     public void testUsingBreakOnMatchSpecificCase() {
         ResponseEntity<String> response = this.restTemplate.getForEntity("/serviceF", String.class);
         HttpHeaders headers = response.getHeaders();
-        String key = "rate-limit-application_serviceF_127.0.0.1";
-        assertHeaders(headers, key, true, false);
+        String key = "rate-limit-application_serviceF_127.0.0.1_127.0.0.1";
+        assertHeaders(headers, key, false, false);
         assertEquals(OK, response.getStatusCode());
 
         response = this.restTemplate.getForEntity("/serviceF", String.class);
         headers = response.getHeaders();
-        assertHeaders(headers, key, true, false);
+        assertHeaders(headers, key, false, false);
+        assertEquals(OK, response.getStatusCode());
+    }
+
+    @Test
+    public void testUsingBreakOnMatchSpecificCaseWithCidr() {
+        ResponseEntity<String> response = this.restTemplate.getForEntity("/serviceH", String.class);
+        HttpHeaders headers = response.getHeaders();
+        String key = "rate-limit-application_serviceH_127.0.0.1_127.0.0.0_22";
+        assertHeaders(headers, key, false, false);
+        assertEquals(OK, response.getStatusCode());
+
+        response = this.restTemplate.getForEntity("/serviceH", String.class);
+        headers = response.getHeaders();
+        assertHeaders(headers, key, false, false);
         assertEquals(OK, response.getStatusCode());
     }
 
@@ -144,13 +158,27 @@ public class SpringDataApplicationTestIT {
         ResponseEntity<String> response = this.restTemplate.getForEntity("/serviceG", String.class);
         HttpHeaders headers = response.getHeaders();
         String key = "rate-limit-application_serviceG_127.0.0.1";
-        assertHeaders(headers, key, true, false);
+        assertHeaders(headers, key, false, false);
         assertEquals(OK, response.getStatusCode());
 
         response = this.restTemplate.getForEntity("/serviceG", String.class);
         headers = response.getHeaders();
-        assertHeaders(headers, key, true, false);
+        assertHeaders(headers, key, false, false);
+        assertEquals(TOO_MANY_REQUESTS, response.getStatusCode());
+    }
+
+    @Test
+    public void testUsingBreakOnMatchGeneralCaseWithCidr() {
+        ResponseEntity<String> response = this.restTemplate.getForEntity("/serviceI", String.class);
+        HttpHeaders headers = response.getHeaders();
+        String key = "rate-limit-application_serviceI_127.0.0.1";
+        assertHeaders(headers, key, false, false);
         assertEquals(OK, response.getStatusCode());
+
+        response = this.restTemplate.getForEntity("/serviceI", String.class);
+        headers = response.getHeaders();
+        assertHeaders(headers, key, false, false);
+        assertEquals(TOO_MANY_REQUESTS, response.getStatusCode());
     }
 
     private void assertHeaders(HttpHeaders headers, String key, boolean nullable, boolean quotaHeaders) {


### PR DESCRIPTION
* Fixed bug so that it only applies one limit per request

* Added the breakOnMatch option so that the previous commit can either be enabled or disabled for every policy

* Fixed issue 165 so CIDR notation is a valid input on origin.

* Added try catch block so that it won't throw errors when given incorrect input, it will just return false.

* Makes the same fix as 165 but for the 1.7.x branch.

* Implemented unit tests of the previous versions.

* Small formatting changes.

* Implemented unit tests of the previous versions.

* Small formatting changes.

Fixes #

#### Changes proposed in this pull request:
 - 
 -
 -
 
